### PR TITLE
Fix panic on invalid language or file path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ impl Opt {
                         .collect()
                 } else {
                     let file = fs::File::open(path).map_err(|e| {
-                        format!("Error: Cannot open '{}': {}", path.display(), e)
+                        format!("Error: Cannot read '{}': {}", path.display(), e)
                     })?;
                     io::BufReader::new(file)
                         .lines()
@@ -130,7 +130,14 @@ impl Opt {
 
                 let mut language: Vec<&str> = str::from_utf8(&bytes)
                     .map_err(|_| {
-                        "Error: Language file has invalid UTF-8 encoding.".to_string()
+                        if let Some(lang_file) = &self.language_file {
+                            format!(
+                                "Error: Language file '{}' has invalid UTF-8 encoding.",
+                                lang_file.display()
+                            )
+                        } else {
+                            format!("Error: Language '{}' has invalid UTF-8 encoding.", lang_name)
+                        }
                     })?
                     .lines()
                     .collect();

--- a/tests/invalid_input.rs
+++ b/tests/invalid_input.rs
@@ -14,7 +14,7 @@ fn unique_temp_dir(name: &str) -> std::path::PathBuf {
 #[test]
 fn nonexistent_file_exits_cleanly() {
     let output = Command::new(ttyper_bin())
-        .arg("/tmp/ttyper_nonexistent_file_xyz_42.txt")
+        .arg(std::env::temp_dir().join("ttyper_nonexistent_xyz_42.txt"))
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
@@ -36,7 +36,7 @@ fn nonexistent_file_exits_cleanly() {
 
     // Should mention the file path in the error
     assert!(
-        stderr.contains("Cannot open"),
+        stderr.contains("Cannot read"),
         "Expected error about file not found, got: {}",
         stderr
     );
@@ -84,7 +84,7 @@ fn invalid_language_exits_cleanly() {
 fn nonexistent_language_file_exits_cleanly() {
     let output = Command::new(ttyper_bin())
         .arg("--language-file")
-        .arg("/tmp/ttyper_nonexistent_lang_xyz_42.txt")
+        .arg(std::env::temp_dir().join("ttyper_nonexistent_lang_xyz_42.txt"))
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .output()
@@ -177,7 +177,7 @@ fn help_as_path_exits_cleanly() {
 
     // Should show an error about not being able to open the file
     assert!(
-        stderr.contains("Cannot open"),
+        stderr.contains("Cannot read"),
         "Expected file-not-found error for 'help', got: {}",
         stderr
     );


### PR DESCRIPTION
## Summary

- Replace all `expect()` / `?` panics in `gen_contents()` with specific, user-friendly error messages
- Change return type from `Option<Vec<String>>` to `Result<Vec<String>, String>` to carry error context
- Fix silent fallthrough when `--language-file` points to nonexistent file (previously silently used default language)

## Error messages

| Scenario | Before | After |
|----------|--------|-------|
| `ttyper help` | `thread 'main' panicked at 'Error reading language file.'` | `Error: Cannot open 'help': No such file or directory` |
| `ttyper -l xyz` | `thread 'main' panicked at 'Couldn't get test contents...'` | `Error: Language 'xyz' not found. Use --list-languages to see available languages.` |
| `ttyper --language-file binary.bin` | `thread 'main' panicked at 'Language file had non-utf8 encoding.'` | `Error: Language file has invalid UTF-8 encoding.` |
| `ttyper --language-file /nonexistent` | silently used default language | `Error: Cannot read language file '/nonexistent': No such file or directory` |

## Test plan

- [x] 5 new integration tests in `tests/invalid_input.rs`
- [x] All 25 tests pass (16 unit + 4 empty_input + 5 invalid_input)
- [x] Release build succeeds

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)