### PR TITLE
Add TAB key to restart typing test

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -353,6 +353,19 @@ mod tests {
     }
 
     #[test]
+    fn tab_does_not_affect_progress() {
+        let mut test = Test::new(vec!["hello".to_string()], true, false);
+        type_string(&mut test, "he");
+
+        test.handle_key(press(KeyCode::Tab));
+        assert_eq!(
+            test.words[0].progress, "he",
+            "Tab should not modify word progress (handled in main.rs, not handle_key)"
+        );
+        assert_eq!(test.current_word, 0);
+    }
+
+    #[test]
     fn ctrl_w_still_clears_entire_word() {
         let mut test = Test::new(vec!["hello".to_string()], true, false);
         type_string(&mut test, "hel");


### PR DESCRIPTION
## Summary
- TAB during a test immediately restarts with new random words
- No history entry is saved (TAB = abort, unlike Esc which saves)
- TAB on results screen intentionally not handled (r/p/q already exist)

## Design Decisions
- **No save on TAB:** Distinguishes TAB (quick abort) from Esc (save + show results)
- **Only during test:** Results screen already has dedicated keybindings
- **Mirrors monkeytype UX:** TAB as quick-restart is the de facto standard

## Test plan
- [x] 1 new unit test in `src/test/mod.rs` (TAB doesn't affect handle_key progress)
- [x] All 40 tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)