### PR TITLE
Fix invisible block titles on light terminal backgrounds

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -85,7 +85,6 @@ impl Default for Theme {
             default: Style::default(),
 
             title: Style::default()
-                .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
 
             input_border: Style::default().fg(Color::Cyan),


### PR DESCRIPTION
## Summary
- Remove hardcoded `Color::White` from the default `title` style in `config.rs`
- Uses `Color::Reset` (terminal default foreground) instead, which adapts to both light and dark terminal themes
- Affects all Block titles: Overview, Worst Keys, Input, Prompt, Chart

## Root Cause
`theme.title` was `Style::default().fg(Color::White).add_modifier(Modifier::BOLD)`. On light terminal backgrounds (e.g. Ghostty with light theme), `Color::White` produces white text on white background — completely invisible. The text was confirmed present via mouse selection (inverted colors reveal the title).

## Test plan
- [x] All 42 tests pass (no new tests — pure style change, one deleted line)
- [x] Visual verification: Block titles now visible on light terminal background

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)