### PR TITLE
Add configurable history file path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,13 @@ use serde::{
     de::{self, IntoDeserializer},
     Deserialize,
 };
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub default_language: String,
+    pub history_file: Option<PathBuf>,
     pub theme: Theme,
 }
 
@@ -18,6 +20,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             default_language: "english200".into(),
+            history_file: None,
             theme: Theme::default(),
         }
     }
@@ -345,5 +348,29 @@ mod tests {
         assert_eq!(border_type("thick"), BorderType::Thick);
         assert_eq!(border_type("quadrantinside"), BorderType::QuadrantInside);
         assert_eq!(border_type("quadrantoutside"), BorderType::QuadrantOutside);
+    }
+
+    #[test]
+    fn config_default_has_no_history_file() {
+        let config = Config::default();
+        assert!(config.history_file.is_none());
+    }
+
+    #[test]
+    fn config_with_history_file() {
+        let toml_str = r#"history_file = "/custom/path/history.csv""#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.history_file,
+            Some(PathBuf::from("/custom/path/history.csv"))
+        );
+    }
+
+    #[test]
+    fn config_without_history_file() {
+        let toml_str = r#"default_language = "german""#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.history_file.is_none());
+        assert_eq!(config.default_language, "german");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,9 +208,11 @@ impl Opt {
         self.config_dir().join("language")
     }
 
-    /// History file path
+    /// History file path (configurable via config.toml, falls back to default)
     fn history_file(&self) -> PathBuf {
-        self.config_dir().join("history.csv")
+        self.config()
+            .history_file
+            .unwrap_or_else(|| self.config_dir().join("history.csv"))
     }
 
     /// Get the effective language name for history logging


### PR DESCRIPTION
## Summary
- Users can now set `history_file = "/path/to/history.csv"` in `config.toml` to override the default location
- Falls back to `~/.config/ttyper/history.csv` when not configured
- Useful for syncing history across machines or integrating with external systems

## Design Decisions
- Used `Option<PathBuf>` in Config struct — `None` means use default, `Some(path)` overrides
- Leveraged existing `#[serde(default)]` on Config so missing field defaults to `None`
- `Opt::history_file()` reads config and falls back to default path

## Test plan
- [x] 3 new tests in `src/config.rs` (default has no history_file, with custom path, without field)
- [x] All 53 tests pass

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)