### PR TITLE
Add history filtering by language and date range

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,24 @@ fn main() -> io::Result<()> {
     }
 
     if opt.history {
+        if let Some(ref since) = opt.since {
+            if let Err(msg) = history::validate_date_format(since) {
+                eprintln!("{}", msg);
+                return Ok(());
+            }
+        }
+        if let Some(ref until) = opt.until {
+            if let Err(msg) = history::validate_date_format(until) {
+                eprintln!("{}", msg);
+                return Ok(());
+            }
+        }
+        if let (Some(ref since), Some(ref until)) = (&opt.since, &opt.until) {
+            if since > until {
+                eprintln!("Error: --since date must be before or equal to --until date");
+                return Ok(());
+            }
+        }
         let filters = history::Filters {
             language: opt.history_lang.as_deref(),
             since: opt.since.as_deref(),


### PR DESCRIPTION
## Summary
- New `--history-lang LANG` flag filters history by language (exact match)
- New `--since DATE` and `--until DATE` flags filter by date range (YYYY-MM-DD, inclusive)
- All filters AND-combinable with each other and with `--last`
- All filter flags require `--history` (consistent with `--last`)
- Footer shows "Showing X of Y results" when any filter is active

## Design Decisions
- Used `--history-lang` instead of `--language` to avoid conflict with existing `-l/--language` flag
- Date comparison uses string ordering on YYYY-MM-DD prefix (lexicographic = chronologic for ISO dates)
- Filters are applied before `--last` (filter first, then take last N)
- Extracted `matches_filters()` as pure function for testability

## Test plan
- [x] 7 new tests: language filter, date filters, combined filters
- [x] All 60 tests pass (51 unit + 4 empty + 5 invalid)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)