### PR TITLE
Add --no-backspace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Options:
       --no-backtrack          Disable backtracking to completed words
       --sudden-death          Enable sudden death mode to restart on first error
       --case-insensitive      Ignore case when comparing typed input
+      --no-backspace          Disable backspace/delete during test
       --history               Show history of past results
       --last <N>              Show only the last N history entries
       --history-lang <LANG>   Filter history by language

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ struct Opt {
     #[arg(long)]
     case_insensitive: bool,
 
+    /// Disable backspace/delete during test
+    #[arg(long)]
+    no_backspace: bool,
+
     /// Show history of past results
     #[arg(long)]
     history: bool,
@@ -387,6 +391,7 @@ fn main() -> io::Result<()> {
         !opt.no_backtrack,
         opt.sudden_death,
         opt.case_insensitive,
+        opt.no_backspace,
     ));
 
     state.render_into(&mut terminal, &config)?;
@@ -436,6 +441,7 @@ fn main() -> io::Result<()> {
                                     !opt.no_backtrack,
                                     opt.sudden_death,
                                     opt.case_insensitive,
+                                    opt.no_backspace,
                                 ));
                             }
                             _ => continue,
@@ -470,6 +476,7 @@ fn main() -> io::Result<()> {
                             !opt.no_backtrack,
                             opt.sudden_death,
                             opt.case_insensitive,
+                            opt.no_backspace,
                         ));
                     }
                     _ => continue,
@@ -494,6 +501,7 @@ fn main() -> io::Result<()> {
                         !opt.no_backtrack,
                         opt.sudden_death,
                         opt.case_insensitive,
+                        opt.no_backspace,
                     ));
                 }
                 Event::Key(KeyEvent {
@@ -510,6 +518,7 @@ fn main() -> io::Result<()> {
                         !opt.no_backtrack,
                         opt.sudden_death,
                         opt.case_insensitive,
+                        opt.no_backspace,
                     ));
                 }
                 Event::Key(KeyEvent {
@@ -532,6 +541,7 @@ fn main() -> io::Result<()> {
                         !opt.no_backtrack,
                         opt.sudden_death,
                         opt.case_insensitive,
+                        opt.no_backspace,
                     ));
                 }
                 Event::Key(KeyEvent {

--- a/src/test/results.rs
+++ b/src/test/results.rs
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn non_target_key_excluded_from_per_key() {
-        let mut test = Test::new(vec!["abc".to_string()], true, false, false);
+        let mut test = Test::new(vec!["abc".to_string()], true, false, false, false);
         test.words[0].events.push(make_event('a', true));
         test.words[0].events.push(make_event('x', false)); // 'x' not in "abc"
         test.words[0].events.push(make_event('b', true));
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn non_target_key_still_counted_in_overall() {
-        let mut test = Test::new(vec!["ab".to_string()], true, false, false);
+        let mut test = Test::new(vec!["ab".to_string()], true, false, false, false);
         test.words[0].events.push(make_event('a', true));
         test.words[0].events.push(make_event('x', false)); // wrong key, not in target
         test.words[0].events.push(make_event('b', true));
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn target_key_with_errors_tracked_correctly() {
-        let mut test = Test::new(vec!["aa".to_string()], true, false, false);
+        let mut test = Test::new(vec!["aa".to_string()], true, false, false, false);
         test.words[0].events.push(make_event('a', true));
         test.words[0].events.push(make_event('a', false)); // 'a' is in target but typed wrong position
 
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn shift_variant_of_target_key_tracked() {
         // Target has lowercase 'e', user types uppercase 'E' (Shift mistake)
-        let mut test = Test::new(vec!["hello".to_string()], true, false, false);
+        let mut test = Test::new(vec!["hello".to_string()], true, false, false, false);
         test.words[0].events.push(make_event('h', true));
         test.words[0].events.push(make_event('E', false)); // Shift-variant of 'e'
         test.words[0].events.push(make_event('l', true));
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn multiple_non_target_keys_all_excluded() {
-        let mut test = Test::new(vec!["a".to_string()], true, false, false);
+        let mut test = Test::new(vec!["a".to_string()], true, false, false, false);
         test.words[0].events.push(make_event('a', true));
         test.words[0].events.push(make_event('x', false));
         test.words[0].events.push(make_event('y', false));
@@ -381,6 +381,7 @@ mod tests {
             true,
             false,
             false,
+            false,
         );
 
         // "fast" — 4 chars in 0.4s = 0.1s/char
@@ -424,6 +425,7 @@ mod tests {
             true,
             false,
             false,
+            false,
         );
 
         // "correct" — typed correctly
@@ -460,6 +462,7 @@ mod tests {
             true,
             false,
             false,
+            false,
         );
 
         // "a" — only 1 event (can't measure timing)
@@ -483,7 +486,7 @@ mod tests {
     fn slow_words_caps_at_five() {
         let now = Instant::now();
         let words: Vec<String> = (0..10).map(|i| format!("word{}", i)).collect();
-        let mut test = Test::new(words, true, false, false);
+        let mut test = Test::new(words, true, false, false, false);
 
         for (wi, word) in test.words.iter_mut().enumerate() {
             for (ci, c) in word.text.clone().chars().enumerate() {
@@ -502,7 +505,7 @@ mod tests {
     #[test]
     fn results_preserve_word_list() {
         let words = vec!["hello".to_string(), "world".to_string(), "test".to_string()];
-        let test = Test::new(words.clone(), true, false, false);
+        let test = Test::new(words.clone(), true, false, false, false);
 
         let results = Results::from(&test);
 
@@ -519,7 +522,7 @@ mod tests {
             "apple".to_string(),
             "mango".to_string(),
         ];
-        let test = Test::new(words.clone(), true, false, false);
+        let test = Test::new(words.clone(), true, false, false, false);
 
         let results = Results::from(&test);
 
@@ -535,7 +538,7 @@ mod tests {
 
     #[test]
     fn dwell_no_release_events() {
-        let mut test = Test::new(vec!["abc".to_string()], true, false, false);
+        let mut test = Test::new(vec!["abc".to_string()], true, false, false, false);
         test.words[0].events.push(make_event('a', true));
         test.words[0].events.push(make_event('b', true));
         test.words[0].events.push(make_event('c', true));
@@ -552,7 +555,7 @@ mod tests {
     #[test]
     fn dwell_with_release_events() {
         let now = Instant::now();
-        let mut test = Test::new(vec!["ab".to_string()], true, false, false);
+        let mut test = Test::new(vec!["ab".to_string()], true, false, false, false);
 
         // 'a' held for 80ms, 'b' held for 120ms
         test.words[0].events.push(make_dwell_event(
@@ -581,7 +584,7 @@ mod tests {
     #[test]
     fn dwell_mixed_events() {
         let now = Instant::now();
-        let mut test = Test::new(vec!["abc".to_string()], true, false, false);
+        let mut test = Test::new(vec!["abc".to_string()], true, false, false, false);
 
         // 'a' has release (100ms), 'b' does not, 'c' has release (50ms)
         test.words[0].events.push(make_dwell_event(
@@ -614,7 +617,7 @@ mod tests {
     #[test]
     fn dwell_per_key_averages() {
         let now = Instant::now();
-        let mut test = Test::new(vec!["aa".to_string()], true, false, false);
+        let mut test = Test::new(vec!["aa".to_string()], true, false, false, false);
 
         // Two presses of 'a': 60ms and 100ms → avg 80ms
         test.words[0].events.push(make_dwell_event(


### PR DESCRIPTION
## Summary
- Adds `--no-backspace` CLI flag that disables Backspace, Ctrl-H, and Ctrl-W during tests
- Forces forward-only typing for accuracy-focused practice
- Combinable with `--sudden-death` for maximum difficulty

## Test plan
- [x] 4 new unit tests (blocks backspace, blocks ctrl-h, blocks ctrl-w, still allows typing)
- [x] All 87 tests pass (78 unit + 9 integration)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)