### PR TITLE
Add --no-shuffle and --no-limit flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Options:
       --sudden-death          Enable sudden death mode to restart on first error
       --case-insensitive      Ignore case when comparing typed input
       --no-backspace          Disable backspace/delete during test
+      --no-shuffle            Don't shuffle word order
+      --no-limit              Use entire word list (ignore --words limit)
       --history               Show history of past results
       --last <N>              Show only the last N history entries
       --history-lang <LANG>   Filter history by language

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,14 @@ struct Opt {
     #[arg(long)]
     no_backspace: bool,
 
+    /// Don't shuffle word order
+    #[arg(long)]
+    no_shuffle: bool,
+
+    /// Use entire word list (ignore --words limit)
+    #[arg(long)]
+    no_limit: bool,
+
     /// Show history of past results
     #[arg(long)]
     history: bool,
@@ -177,15 +185,23 @@ impl Opt {
                     })?
                     .lines()
                     .collect();
-                language.shuffle(&mut rng);
+                if !self.no_shuffle {
+                    language.shuffle(&mut rng);
+                }
 
-                let mut contents: Vec<_> = language
-                    .into_iter()
-                    .cycle()
-                    .take(self.words.get())
-                    .map(ToOwned::to_owned)
-                    .collect();
-                contents.shuffle(&mut rng);
+                let mut contents: Vec<_> = if self.no_limit {
+                    language.into_iter().map(ToOwned::to_owned).collect()
+                } else {
+                    language
+                        .into_iter()
+                        .cycle()
+                        .take(self.words.get())
+                        .map(ToOwned::to_owned)
+                        .collect()
+                };
+                if !self.no_shuffle {
+                    contents.shuffle(&mut rng);
+                }
 
                 Ok(contents)
             }


### PR DESCRIPTION
## Summary
- `--no-shuffle`: Preserves original word order from language files
- `--no-limit`: Uses entire word list, ignoring `-w` word count limit
- Both flags affect only language-based content generation (not file/stdin input)

## Test plan
- [x] All 87 tests pass
- [x] Clippy + rustfmt clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)